### PR TITLE
Fix for hook manifest issue (#403)

### DIFF
--- a/docs/tutorials/write-a-hookscript.md
+++ b/docs/tutorials/write-a-hookscript.md
@@ -33,12 +33,13 @@ To create a new OTIO hook script, you need to create a file myhooks.py. Then add
             "OTIO_SCHEMA" : "HookScript.1",
             "name" : "example hook",
             "execution_scope" : "in process",
-            "filepath" : "example.py"
+            "filepath" : "myhooks.py"
         }
     ],
     "hooks" : {
         "pre_adapter_write" : ["example hook"],
-        "post_adapter_read" : []
+        "post_adapter_read" : [],
+        "post_media_linker" : []
     }
 }
 ```


### PR DESCRIPTION
* Fix: wrong type for "hooks"
* Fix: _json_path is not set for hook_scripts
* Fix: manifest extend() does not include hooks / hook_scripts
* Fix: added missing hook to tutorial sample code